### PR TITLE
Changement le l'auth, ajout de cache de l'install de lftp, et respect…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,33 @@
 # Deploy to Rezoleo via SFTP
 
-This GitHub Action allows you to deploy content to Rezoleo's Hippolyte server via SFTP using `lftp` and an SSH private key. It automates the preparation of a clean folder and the deployment process. It deploys the content to the `writable` folder on the server.
+This GitHub Action allows you to deploy content to Rezoleo's Hippolyte server via SFTP using `lftp` and an SSH private key or a password. It automates the deployment process while removing the `.git` folder as well as the `.gitignore`. It deploys the content to the `writable` folder on the server.
 
 ## Features
-- Prepares a clean folder for deployment.
+- Checks if the inputs are correct (either a key or a password must be provided).
 - Installs `lftp` for SFTP operations.
-- Deploys content securely using an SSH private key.
+- Deploys content securely using an SSH private key or a password.
 
 ## Inputs
-
-### `sftp-key`
-**Required**
-
-The SSH private key for the SFTP server. This key is used to authenticate the deployment process.
-
-You must ask a Rezoleo administrator to add your dedicated public key to your user on the server.
 
 ### `sftp-user`
 **Required**
 
 The username for the SFTP server.
+
+### `sftp-password`
+**Partially optionnal**
+
+The password for the SFTP server. This password is used to authenticate the deployment process.
+
+### `sftp-key`
+**Partially optionnal**
+
+The SSH private key for the SFTP server. This key is used to authenticate the deployment process.
+
+You must ask a Rezoleo administrator to add your dedicated public key to your user on the server.
+
+> [!IMPORTANT] 
+> You must either provide a key, or a password, not both!
 
 ## Usage
 
@@ -44,25 +52,24 @@ jobs:
       - name: Deploy to Rezoleo
         uses: rezoleo/rezoleo-deploy-action@v1
         with:
-          sftp-key: ${{ secrets.SFTP_KEY }}
           sftp-user: ${{ secrets.SFTP_USER }}
+          # Use only one of the following lines :
+          #sftp-password: ${{ secrets.SFTP_PASSWORD }}
+          sftp-key: ${{ secrets.SFTP_KEY }}
 ```
 
 ## Secrets
 
 You need to define the following secrets in your repository:
 
-- `SFTP_KEY`: The SSH private key for the SFTP server.
 - `SFTP_USER`: The username for the SFTP server.
-
-## Scripts
-
-This action uses the following scripts:
-- `scripts/prepare-upload.sh`
-- `scripts/deploy.sh`
+- `SFTP_PASSWORD`: The password for the SFTP server.
+- `SFTP_KEY`: The SSH private key for the SFTP server.
 
 ## Notes
 
-- A new folder named `clean_upload` is created during the deployment process.
 - The SSH private key is written to a file named `id_rsa` during the deployment process.
-- Caution : the upload process will overwrite completely the content in the `writable` folder on the server.
+- Caution : The upload process will completely overwrite the content in the `writable` folder on the server, except the `.git` folder and what is included in the `.gitignore` file.
+
+> [!WARNING] 
+> Include directives present in the `.gitignore` files (lines starting with `!`) are not respected!

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ This GitHub Action allows you to deploy content to Rezoleo's Hippolyte server vi
 The username for the SFTP server.
 
 ### `sftp-password`
-**Partially optionnal**
+**Partially optional**
 
 The password for the SFTP server. This password is used to authenticate the deployment process.
 
 ### `sftp-key`
-**Partially optionnal**
+**Partially optional**
 
 The SSH private key for the SFTP server. This key is used to authenticate the deployment process.
 

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
       shell: bash
 
     - name: Installer lftp
-      uses: awalsh128/cache-apt-pkgs-action@latest
+      uses: awalsh128/cache-apt-pkgs-action@1.5
       with:
         packages: lftp
         version: 1.0

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
       shell: bash
 
     - name: Installer lftp
-      uses: awalsh128/cache-apt-pkgs-action@1.5
+      uses: awalsh128/cache-apt-pkgs-action@1.5.1
       with:
         packages: lftp
         version: 1.0

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
       shell: bash
 
     - name: Installer lftp
-      uses: awalsh128/cache-apt-pkgs-action@v1.5.*
+      uses: awalsh128/cache-apt-pkgs-action@v1.5.1
       with:
         packages: lftp
         version: 1.0

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
       shell: bash
 
     - name: Installer lftp
-      uses: awalsh128/cache-apt-pkgs-action@1.5.1
+      uses: awalsh128/cache-apt-pkgs-action@v1.5.*
       with:
         packages: lftp
         version: 1.0

--- a/action.yml
+++ b/action.yml
@@ -1,26 +1,56 @@
 name: 'Deploy to Rezoleo via SFTP'
-description: 'Déploie le contenu du repo sur Hippolyte via SFTP avec lftp + user/password, en ignorant .git/ et en respectant partiellement le .gitignore'
+description: 'Déploie le contenu du repo sur Hippolyte via SFTP avec lftp, en ignorant .git/ et en respectant partiellement le .gitignore. Un mot de passe ou (exclusif) une clé doivent être fournis.'
 inputs:
-  sftp-password:
-    description: 'Mot de passe pour le serveur SFTP'
-    required: true
   sftp-user:
     description: 'Nom d’utilisateur pour le serveur SFTP'
     required: true
+  sftp-password:
+    description: 'Mot de passe pour le serveur SFTP'
+    required: false
+  sftp-key:
+    description: 'Clé privée SSH pour le serveur SFTP'
+    required: false
 
 runs:
   using: "composite"
   steps:
+    - name: Vérifier les entrées
+      run: |
+        A="${{ inputs.sftp-password }}"
+        B="${{ inputs.sftp-key }}"
+
+        if { [[ -n "$A" && -z "$B" ]] || [[ -z "$A" && -n "$B" ]]; }; then
+          echo "Validé : Une seule entrée pour l'authentification a bien été fournie."
+        else
+          echo "Erreur : Une et une seule des entrées d'authentification (Mot de passe/Clé privé SSH) doit être fournie."
+          exit 1
+        fi
+      shell: bash
+
     - name: Installer lftp
       uses: awalsh128/cache-apt-pkgs-action@latest
       with:
         packages: lftp
         version: 1.0
 
-    - name: Déployer via lftp
+    - name: Déployer via lftp avec un mot de passe
+      if: ${{ inputs.sftp-password != '' }}
       env:
         SFTP_USER: ${{ inputs.sftp-user }}
         SFTP_PASSWORD: ${{ inputs.sftp-password }}
       run: |
-        lftp -p 8888 "sftp://$SFTP_USER:$SFTP_PASSWORD@sftp.rezoleo.fr" -e "set sftp:auto-confirm yes; mirror -e -R -x .git --exclude-glob-from=.gitignore ./ ./writable ; quit"
+        lftp -p 8888 "sftp://$SFTP_USER:$SFTP_PASSWORD@sftp.rezoleo.fr" -e "set cmd:trace true; set sftp:auto-confirm yes; mirror -e -R -x .git --exclude-glob-from=.gitignore ./ ./writable ; quit" -d
+      shell: bash
+
+    - name: Écrire la clé privée
+      if: ${{ inputs.sftp-key != '' }}
+      run: |
+        echo "${{ inputs.sftp-key }}" > id_rsa
+        chmod 600 id_rsa
+      shell: bash
+
+    - name: Déployer via lftp
+      if: ${{ inputs.sftp-key != '' }}
+      run: |
+        lftp -u "${{ inputs.sftp-user }}","" -e "set cmd:trace true; set sftp:connect-program 'ssh -i ./id_rsa -o StrictHostKeyChecking=no -p 8888'; set ssl:verify-certificate no; mirror -e -R -x .git/ --exclude-glob-from=.gitignore ./ /writable/; quit" -d sftp://sftp.rezoleo.fr
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,8 @@
 name: 'Deploy to Rezoleo via SFTP'
-description: 'Prépare un dossier et déploie son contenu sur Hippolyte via SFTP avec lftp + clé SSH'
+description: 'Déploie le contenu du repo sur Hippolyte via SFTP avec lftp + user/password, en ignorant .git/ et en respectant partiellement le .gitignore'
 inputs:
-  sftp-key:
-    description: 'Clé privée SSH pour le serveur SFTP'
+  sftp-password:
+    description: 'Mot de passe pour le serveur SFTP'
     required: true
   sftp-user:
     description: 'Nom d’utilisateur pour le serveur SFTP'
@@ -11,26 +11,16 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Préparer le dossier clean
-      run: |
-        mkdir upload_clean
-        shopt -s dotglob
-        find . -mindepth 1 -maxdepth 1 ! -name upload_clean -exec cp -r {} upload_clean/ \;
-        rm -rf upload_clean/.git
-      shell: bash
-
     - name: Installer lftp
-      run: sudo apt-get update && sudo apt-get install -y lftp
-      shell: bash
-
-    - name: Écrire la clé privée
-      run: |
-        echo "${{ inputs.sftp-key }}" > id_rsa
-        chmod 600 id_rsa
-      shell: bash
+      uses: awalsh128/cache-apt-pkgs-action@latest
+      with:
+        packages: lftp
+        version: 1.0
 
     - name: Déployer via lftp
+      env:
+        SFTP_USER: ${{ inputs.sftp-user }}
+        SFTP_PASSWORD: ${{ inputs.sftp-password }}
       run: |
-        cd upload_clean
-        lftp -u "${{ inputs.sftp-user }}","" -e "set sftp:connect-program 'ssh -i ../id_rsa -o StrictHostKeyChecking=no -p 8888'; set ssl:verify-certificate no; mirror -R --delete --exclude-glob .git/ ./ /writable/; bye" sftp://sftp.rezoleo.fr
+        lftp -p 8888 "sftp://$SFTP_USER:$SFTP_PASSWORD@sftp.rezoleo.fr" -e "set sftp:auto-confirm yes; mirror -e -R -x .git --exclude-glob-from=.gitignore ./ ./writable ; quit"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -1,56 +1,56 @@
 name: 'Deploy to Rezoleo via SFTP'
-description: 'Déploie le contenu du repo sur Hippolyte via SFTP avec lftp, en ignorant .git/ et en respectant partiellement le .gitignore. Un mot de passe ou (exclusif) une clé doivent être fournis.'
+description: 'Deploys the repo's content to Hippolyte via SFTP with lftp, ignoring the .git/ folder and respecting the .gitignore. A password XOR an SSH key needs to be provided.'
 inputs:
   sftp-user:
-    description: 'Nom d’utilisateur pour le serveur SFTP'
+    description: 'Username for the SFTP server'
     required: true
   sftp-password:
-    description: 'Mot de passe pour le serveur SFTP'
+    description: 'Password for the SFTP server'
     required: false
   sftp-key:
-    description: 'Clé privée SSH pour le serveur SFTP'
+    description: 'SSH key for the SFTP server'
     required: false
 
 runs:
   using: "composite"
   steps:
-    - name: Vérifier les entrées
+    - name: Verify the inputs
       run: |
         A="${{ inputs.sftp-password }}"
         B="${{ inputs.sftp-key }}"
 
         if { [[ -n "$A" && -z "$B" ]] || [[ -z "$A" && -n "$B" ]]; }; then
-          echo "Validé : Une seule entrée pour l'authentification a bien été fournie."
+          echo "Good : A single means of authentication has been provided, as requested."
         else
-          echo "Erreur : Une et une seule des entrées d'authentification (Mot de passe/Clé privé SSH) doit être fournie."
+          echo "Error : Only a single means of authentication needs to be provided (password xor key)."
           exit 1
         fi
       shell: bash
 
-    - name: Installer lftp
+    - name: Install lftp package
       uses: awalsh128/cache-apt-pkgs-action@v1.5.1
       with:
         packages: lftp
         version: 1.0
 
-    - name: Déployer via lftp avec un mot de passe
+    - name: Deploy via lftp with password
       if: ${{ inputs.sftp-password != '' }}
       env:
         SFTP_USER: ${{ inputs.sftp-user }}
         SFTP_PASSWORD: ${{ inputs.sftp-password }}
       run: |
-        lftp -p 8888 "sftp://$SFTP_USER:$SFTP_PASSWORD@sftp.rezoleo.fr" -e "set cmd:trace true; set sftp:auto-confirm yes; mirror -e -R -x .git --exclude-glob-from=.gitignore ./ ./writable ; quit" -d
+        lftp -p 8888 "sftp://$SFTP_USER:$SFTP_PASSWORD@sftp.rezoleo.fr" -e "set cmd:trace true; set sftp:auto-confirm yes; mirror -e -R -x .git --exclude-glob-from=.gitignore ./ ./writable ; quit"
       shell: bash
 
-    - name: Écrire la clé privée
+    - name: Write the private key
       if: ${{ inputs.sftp-key != '' }}
       run: |
         echo "${{ inputs.sftp-key }}" > id_rsa
         chmod 600 id_rsa
       shell: bash
 
-    - name: Déployer via lftp
+    - name: Deploy via lftp with key
       if: ${{ inputs.sftp-key != '' }}
       run: |
-        lftp -u "${{ inputs.sftp-user }}","" -e "set cmd:trace true; set sftp:connect-program 'ssh -i ./id_rsa -o StrictHostKeyChecking=no -p 8888'; set ssl:verify-certificate no; mirror -e -R -x .git/ --exclude-glob-from=.gitignore ./ /writable/; quit" -d sftp://sftp.rezoleo.fr
+        lftp -u "${{ inputs.sftp-user }}","" -e "set cmd:trace true; set sftp:connect-program 'ssh -i ./id_rsa -o StrictHostKeyChecking=no -p 8888'; set ssl:verify-certificate no; mirror -e -R -x .git/ --exclude-glob-from=.gitignore ./ /writable/; quit" sftp://sftp.rezoleo.fr
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ runs:
         SFTP_USER: ${{ inputs.sftp-user }}
         SFTP_PASSWORD: ${{ inputs.sftp-password }}
       run: |
-        lftp -p 8888 "sftp://$SFTP_USER:$SFTP_PASSWORD@sftp.rezoleo.fr" -e "set cmd:trace true; set sftp:auto-confirm yes; mirror -e -R -x .git --exclude-glob-from=.gitignore ./ ./writable ; quit"
+        lftp -p 8888 "sftp://$SFTP_USER:$SFTP_PASSWORD@sftp.rezoleo.fr" -e "set cmd:trace true; set sftp:auto-confirm yes; mirror --delete --reverse --exclude=.git --exclude-glob-from=.gitignore ./ ./writable ; quit"
       shell: bash
 
     - name: Write the private key
@@ -52,5 +52,5 @@ runs:
     - name: Deploy via lftp with key
       if: ${{ inputs.sftp-key != '' }}
       run: |
-        lftp -u "${{ inputs.sftp-user }}","" -e "set cmd:trace true; set sftp:connect-program 'ssh -i ./id_rsa -o StrictHostKeyChecking=no -p 8888'; set ssl:verify-certificate no; mirror -e -R -x .git/ --exclude-glob-from=.gitignore ./ /writable/; quit" sftp://sftp.rezoleo.fr
+        lftp -u "${{ inputs.sftp-user }}","" -e "set cmd:trace true; set sftp:connect-program 'ssh -i ./id_rsa -o StrictHostKeyChecking=no -p 8888'; set ssl:verify-certificate no; mirror --delete --reverse --exclude=.git/ --exclude-glob-from=.gitignore ./ /writable/; quit" sftp://sftp.rezoleo.fr
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'Deploy to Rezoleo via SFTP'
-description: 'Deploys the repo's content to Hippolyte via SFTP with lftp, ignoring the .git/ folder and respecting the .gitignore. A password XOR an SSH key needs to be provided.'
+description: "Deploys the repo's content to Hippolyte via SFTP with lftp, ignoring the .git/ folder and respecting the .gitignore. A password XOR an SSH key needs to be provided."
 inputs:
   sftp-user:
     description: 'Username for the SFTP server'

--- a/action.yml
+++ b/action.yml
@@ -42,15 +42,15 @@ runs:
         lftp -p 8888 "sftp://$SFTP_USER:$SFTP_PASSWORD@sftp.rezoleo.fr" -e "set cmd:trace true; set sftp:auto-confirm yes; mirror --delete --reverse --exclude=.git --exclude-glob-from=.gitignore ./ ./writable ; quit"
       shell: bash
 
-    - name: Write the private key
+    - name: Write the private key to ../id_rsa
       if: ${{ inputs.sftp-key != '' }}
       run: |
-        echo "${{ inputs.sftp-key }}" > id_rsa
-        chmod 600 id_rsa
+        echo "${{ inputs.sftp-key }}" > ../id_rsa 
+        chmod 600 ../id_rsa
       shell: bash
 
     - name: Deploy via lftp with key
       if: ${{ inputs.sftp-key != '' }}
       run: |
-        lftp -u "${{ inputs.sftp-user }}","" -e "set cmd:trace true; set sftp:connect-program 'ssh -i ./id_rsa -o StrictHostKeyChecking=no -p 8888'; set ssl:verify-certificate no; mirror --delete --reverse --exclude=.git/ --exclude-glob-from=.gitignore ./ /writable/; quit" sftp://sftp.rezoleo.fr
+        lftp -u "${{ inputs.sftp-user }}","" -e "set cmd:trace true; set sftp:connect-program 'ssh -i ../id_rsa -o StrictHostKeyChecking=no -p 8888'; set ssl:verify-certificate no; mirror --delete --reverse --exclude=.git/ --exclude-glob-from=.gitignore ./ /writable/; quit" sftp://sftp.rezoleo.fr
       shell: bash


### PR DESCRIPTION
… partiel de .gitignore

Pour le .gitignore, les lignes commencant par "!" ne sont pas respectées (je ne sais pas comment elles sont traitées d'ailleurs).
Le dossier .git/ est ignoré directement dans la commande lftp.
Le cache de LFTP permet de passer de 12 à 3s d'installation (c'est sans doute débile et pas utile, mais le cache fait 800Ko donc c'est pas grand chose).

Je n'ai pas pu tester cette action en son état, mais c'est un quasi copié collé de la version tout intégrée, qui fonctionne correctement sur mon repo privé pour le site La REZerve.

Version toute intégrée :
```yml
on:
  push:
    branches:
    - prod
  workflow_dispatch:

jobs:
  deploy:
    runs-on: ubuntu-latest

    steps:
      - name: Checkout code
        uses: actions/checkout@v4

      - name: Install lftp
        uses: awalsh128/cache-apt-pkgs-action@latest
        with:
          packages: lftp
          version: 1.0

      - name: Deploy with lftp (mirror of repo except .gitignore)
        env:
          SFTP_USER: ${{ secrets.SFTP_USER }}
          SFTP_PASSWORD: ${{ secrets.SFTP_PASSWORD }}
        run: |
          lftp -p 8888 "sftp://$SFTP_USER:$SFTP_PASSWORD@sftp.rezoleo.fr" -e "set sftp:auto-confirm yes; mirror -e -R -x .git --exclude-glob-from=.gitignore ./ ./writable ; quit"
```